### PR TITLE
Enable runtime type-checking with Typeguard by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
           - { python-version: 3.8, os: ubuntu-latest, session: "tests" }
           # - { python-version: 3.8, os: windows-latest, session: "tests" }
           - { python-version: 3.8, os: macos-latest, session: "tests" }
+          - { python-version: 3.8, os: ubuntu-latest, session: "typeguard" }
           # - { python-version: 3.8, os: ubuntu-latest, session: "docs" }
 
     env:

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ from nox.sessions import Session
 
 package = "irpf_cei"
 python_versions = ["3.8"]
-nox.options.sessions = "pre-commit", "safety", "mypy", "tests"
+nox.options.sessions = "pre-commit", "safety", "mypy", "tests", "typeguard"
 
 
 class Poetry:


### PR DESCRIPTION
Add Typeguard to Nox sessions and testing workflow.

Closes #130